### PR TITLE
[1.1.13]Add Board Basic Function & fixed React & NodeJS Manual

### DIFF
--- a/backend/mongoServer/models/User.js
+++ b/backend/mongoServer/models/User.js
@@ -4,7 +4,7 @@ const UserSchema = new mongoose.Schema({
   name: {
     type: String,
     required: true,
-    minlength: 3,
+    minlength: 2,
     maxlength: 50,
   },
   email: {

--- a/backend/mongoServer/routes/board.js
+++ b/backend/mongoServer/routes/board.js
@@ -40,7 +40,7 @@ router.post("/write", async (req, res) => {
       const now = new Date();
       const createdAt = now.toLocaleString();
       obj = {
-        writer: req.body._id,
+        writer: req.body.writer,
         title: req.body.title,
         content: req.body.content,
         realContent: req.body.realContent,
@@ -69,12 +69,14 @@ router.post("/detail", async(req,res) => {
  // 게시글 업데이트 ======================================================================================================================
 router.put("/update", async (req,res) => {
     try {
+        
         await Board.updateOne(
             {_id: req.body._id},
             {
                 $set: {
                     title: req.body.title,
-                    content: req.body.content
+                    content: req.body.content,
+                    realContent: req.body.realContent
                 }
             }
         );

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,6 +39,7 @@
         "react-bootstrap": "^2.10.2",
         "react-cookie": "^7.1.4",
         "react-dom": "^18.2.0",
+        "react-paginate": "^8.2.0",
         "react-quill": "^2.0.0",
         "react-redux": "^9.1.2",
         "react-router-dom": "^6.23.1",
@@ -17049,6 +17050,17 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-paginate": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-8.2.0.tgz",
+      "integrity": "sha512-sJCz1PW+9PNIjUSn919nlcRVuleN2YPoFBOvL+6TPgrH/3lwphqiSOgdrLafLdyLDxsgK+oSgviqacF4hxsDIw==",
+      "dependencies": {
+        "prop-types": "^15"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18"
+      }
     },
     "node_modules/react-quill": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "react-bootstrap": "^2.10.2",
     "react-cookie": "^7.1.4",
     "react-dom": "^18.2.0",
+    "react-paginate": "^8.2.0",
     "react-quill": "^2.0.0",
     "react-redux": "^9.1.2",
     "react-router-dom": "^6.23.1",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import Navbar from "./components/Navbar";
 import Home from "./routes/Home";
 import Board from "./routes/Board";
 import BoardDetail from "./routes/BoardDetail";
+import BoardUpdate from "./routes/BoardUpdate";
 import MyEditor from './routes/MyEditor';
 import MyPage from "./routes/MyPage";
 import Register from "./routes/Register";
@@ -62,6 +63,9 @@ import PublicRoute from './utils/PublicRoute'
 // npm install @material-ui/icons
 // 에러 시 npm install typescript --save-dev 후 npm install
 
+// 24.07.26 추가한 모듈
+// npm install react-paginate
+
 const App = () => {
   return (
     <div>
@@ -74,6 +78,7 @@ const App = () => {
             <Route element={<PrivateRoute />}>
                   <Route path="/myeditor" element={<MyEditor />} />
                   <Route path="/mypage" element={<MyPage />} />
+                  <Route exact path = "/board_update/:_id" element = {<BoardUpdate/>}/>
             </Route>
           </Route>
         </Route>

--- a/frontend/src/components/EditorToolBar.js
+++ b/frontend/src/components/EditorToolBar.js
@@ -1,11 +1,68 @@
 /* eslint-disable no-unused-vars */
 import React from 'react';
-// import ReactQuill, {Quill} from 'react-quill';
+import ReactQuill, {Quill} from 'react-quill';
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 import axios from "axios";
 import Button from 'react-bootstrap/Button';
+import ImageResize from 'quill-image-resize';
+import { ImageDrop } from "quill-image-drop-module";
+import katex from 'katex';
+import QuillImageDropAndPaste from 'quill-image-drop-and-paste'
+import htmlEditButton from "quill-html-edit-button";
+import 'katex/dist/katex.min.css'; // formular 활성화
+
+// katex 추가
+window.katex = katex;
+// 모듈 등록
+Quill.register("modules/imageDrop", ImageDrop);
+Quill.register('modules/imageDropAndPaste', QuillImageDropAndPaste);
+Quill.register('modules/ImageResize', ImageResize);
+
+// 폰트 사이즈 추가
+const Size = Quill.import("attributors/style/size");
+Size.whitelist = ["8px", "10px", "12px", 
+"14px", "20px", "24px", "30px", "36px", "48px",
+"60px", "72px", "84px", "96px", "120px"];
+Quill.register(Size, true);
+
+// 폰트 추가
+const Font = Quill.import("attributors/class/font");
+Font.whitelist = ["arial", "buri", "gangwon", "Quill", "serif", "monospace", "끄트머리체", "할아버지의나눔", "나눔고딕", "궁서체", "굴림체", "바탕체", "돋움체"];
+Quill.register(Font, true);
+
+// align & icon 변경
+const Align = ReactQuill.Quill.import("formats/align");
+Align.whitelist = ["left", "center", "right", "justify"];
+const Icons = ReactQuill.Quill.import("ui/icons");
+Icons.align["left"] = Icons.align[""];
+
+// htmlEditButton 적용
+Quill.register({
+  "modules/htmlEditButton":htmlEditButton
+});
+
+// 3D 삽입 기술 정의
+const CustomCanvas = Quill.import('blots/embed');
+class CanvasBlot extends CustomCanvas {
+  static create(value) {
+    const node = super.create();
+    node.setAttribute('width', value.width);
+    node.setAttribute('height', value.height);
+    return node;
+  }
+
+  static value(node) {
+    return {
+      width: node.getAttribute('width'),
+      height: node.getAttribute('height'),
+    };
+  }
+}
+CanvasBlot.blotName = 'canvas';
+CanvasBlot.tagName = 'canvas';
+Quill.register(CanvasBlot);
 
 // handle them correctly
 const CustomUndo = () => (
@@ -39,29 +96,6 @@ const Custom3D = () => (
 );
 
 const CustomHeart = () => <span>♥</span>;
-
-/*
-// 사용자 정의 모듈 정의
-const CustomCanvas = Quill.import('blots/embed');
-class CanvasBlot extends CustomCanvas {
-  static create(value) {
-    const node = super.create();
-    node.setAttribute('width', value.width);
-    node.setAttribute('height', value.height);
-    return node;
-  }
-
-  static value(node) {
-    return {
-      width: node.getAttribute('width'),
-      height: node.getAttribute('height'),
-    };
-  }
-}
-CanvasBlot.blotName = 'canvas';
-CanvasBlot.tagName = 'canvas';
-Quill.register(CanvasBlot);
-*/
 
 const loadModel = (url, Canvas) => {
   const loader = new GLTFLoader();

--- a/frontend/src/css/Board.css
+++ b/frontend/src/css/Board.css
@@ -15,3 +15,29 @@
     margin-bottom: 2rem;
     text-shadow: 3px 3px 5px rgba(0, 0, 0, 0.2);
   }
+
+  .pagination {
+    display: flex;
+    list-style: none;
+    padding: 0;
+    margin-bottom: 150px;
+  }
+  
+  .pagination li {
+    margin: 0 5px;
+  }
+  
+  .pagination li a {
+    text-decoration: none;
+    padding: 8px 12px;
+    border: 1px solid #ddd;
+  }
+  
+  .pagination li a:hover {
+    background-color: #f0f0f0;
+  }
+  
+  .active a {
+    background-color: #007bff;
+    color: white;
+  }

--- a/frontend/src/css/CommonTable.css
+++ b/frontend/src/css/CommonTable.css
@@ -2,8 +2,8 @@
   width: 80%;
   text-align: center;
   
+  margin-bottom: 30px;
   border-collapse: collapse;
-  margin-bottom: 150px;
 }
 
 .common-table-header-column {

--- a/frontend/src/css/MyEditor.css
+++ b/frontend/src/css/MyEditor.css
@@ -160,3 +160,7 @@ font-size: 14px !important;
 .text-editor {
     margin-bottom: 150px;
 }
+
+.text-editor Button {
+  margin-top: 30px;
+}

--- a/frontend/src/css/MyPage.css
+++ b/frontend/src/css/MyPage.css
@@ -81,3 +81,29 @@ a {
   text-decoration: none;
   color: inherit;
 }
+
+.pagination {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  margin-bottom: 150px;
+}
+
+.pagination li {
+  margin: 0 5px;
+}
+
+.pagination li a {
+  text-decoration: none;
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+}
+
+.pagination li a:hover {
+  background-color: #f0f0f0;
+}
+
+.active a {
+  background-color: #007bff;
+  color: white;
+}

--- a/frontend/src/routes/Board.js
+++ b/frontend/src/routes/Board.js
@@ -1,41 +1,67 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
+import ReactPaginate from 'react-paginate';
 
 import CommonTable from '../components/CommonTable';
 import CommonTableColumn from '../components/CommonTableColumn';
 import CommonTableRow from '../components/CommonTableRow';
 import '../css/Board.css';
 
+const ITEMS_PER_PAGE = 10; // 페이지당 항목 수
+
 function Board() {
   const [data, setData] = useState([]);
+  const [pageCount, setPageCount] = useState(0);
+  const [currentPage, setCurrentPage] = useState(0);
 
   useEffect(() => {
     axios.get('http://localhost:5000/board/all_board_list')
       .then((response) => {
         setData(response.data.list);
+        setPageCount(Math.ceil(response.data.list.length / ITEMS_PER_PAGE)); // 총 페이지 수 계산
       })
       .catch((error) => {
         console.error(error);
       });
   }, []);
 
+  // 페이지 변경 핸들러
+  const handlePageClick = (data) => {
+    setCurrentPage(data.selected); // 현재 페이지 업데이트
+  };
+
+  // 현재 페이지에 해당하는 데이터
+  const displayedData = data.slice(currentPage * ITEMS_PER_PAGE, (currentPage + 1) * ITEMS_PER_PAGE);
+
   return (
     <div className="Board">
-      
       {data.length > 0 && (
         <>
-        <h1 className="Board-h1">Board</h1>
-        <CommonTable headersName={['제목[클릭]', '내용', '작성자', '등록일']}>
-          {data.map((item) => (
-            <CommonTableRow key={item._id}>
-              <CommonTableColumn><Link to={`/board_detail/${item._id}`}>{item.title}</Link></CommonTableColumn>
-              <CommonTableColumn>{item.content}</CommonTableColumn>
-              <CommonTableColumn>{item.writer}</CommonTableColumn>
-              <CommonTableColumn>{item.createdAt}</CommonTableColumn>  
-            </CommonTableRow>
-          ))}
-        </CommonTable>
+          <h1 className="Board-h1">Board</h1>
+          <CommonTable headersName={['제목[클릭]', '내용', '작성자', '등록일']}>
+            {displayedData.map((item) => (
+              <CommonTableRow key={item._id}>
+                <CommonTableColumn>
+                  <Link to={`/board_detail/${item._id}`}>{item.title}</Link>
+                </CommonTableColumn>
+                <CommonTableColumn>{item.content}</CommonTableColumn>
+                <CommonTableColumn>{item.writer}</CommonTableColumn>
+                <CommonTableColumn>{item.createdAt}</CommonTableColumn>  
+              </CommonTableRow>
+            ))}
+          </CommonTable>
+          <ReactPaginate
+            previousLabel={'이전'}
+            nextLabel={'다음'}
+            breakLabel={'...'}
+            pageCount={pageCount}
+            marginPagesDisplayed={2}
+            pageRangeDisplayed={5}
+            onPageChange={handlePageClick}
+            containerClassName={'pagination'}
+            activeClassName={'active'}
+          />
         </>
       )}
     </div>

--- a/frontend/src/routes/BoardDetail.js
+++ b/frontend/src/routes/BoardDetail.js
@@ -30,7 +30,7 @@ const BoardDetail = () => {
   }, [params]);
 
   function modifiedBoard() {
-    
+    navigate(`/board_update/${params}`);
   }
   function deleteBoard() {
     if (timeCheck(params) === 0){ 

--- a/frontend/src/routes/MyPage.js
+++ b/frontend/src/routes/MyPage.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import ReactPaginate from 'react-paginate';
 import CommonTable from '../components/CommonTable';
 import CommonTableColumn from '../components/CommonTableColumn';
 import CommonTableRow from '../components/CommonTableRow'
@@ -11,9 +12,13 @@ import { timeCheck} from '../utils/TimeCheck';
 
 import '../css/MyPage.css';
 
+const ITEMS_PER_PAGE = 10; // 페이지당 항목 수
+
 function MyPage() {
   const [time, setTime] = useState('');
   const [data, setData] = useState([]);
+  const [pageCount, setPageCount] = useState(0);
+  const [currentPage, setCurrentPage] = useState(0);
   const [myInf, setMyInf] = useState([]);
   const [password, setPassword] = useState({
     email: localStorage.key(0),
@@ -48,11 +53,12 @@ function MyPage() {
     })
       .then((response) => {
         setData(response.data.list);
+        setPageCount(Math.ceil(response.data.list.length / ITEMS_PER_PAGE)); // 총 페이지 수 계산
       })
       .catch((error) => {
         console.error(error);
     });
-  }, []);
+  }, [navigate]);
 
   const handleChangePassword = async (e) => {
     e.preventDefault();
@@ -122,7 +128,15 @@ function MyPage() {
         }
     });
   }
-// myInf.createdAt
+
+   // 페이지 변경 핸들러
+   const handlePageClick = (data) => {
+    setCurrentPage(data.selected); // 현재 페이지 업데이트
+  };
+
+  // 현재 페이지에 해당하는 데이터
+  const displayedData = data.slice(currentPage * ITEMS_PER_PAGE, (currentPage + 1) * ITEMS_PER_PAGE);
+
   return (
     <div className = "MyPage">
       <div className = "MyPage_No1">
@@ -168,7 +182,7 @@ function MyPage() {
         {data.length > 0 && (<>
           <h1>My Board</h1>
           <CommonTable headersName={['제목[클릭]', '내용', '등록일']}>
-            {data.map((item) => (
+            {displayedData.map((item) => (
               <CommonTableRow key={item._id}>
                 <CommonTableColumn>
                   <Link to={`/board_detail/${item._id}`}>{item.title}</Link>
@@ -177,7 +191,19 @@ function MyPage() {
                 <CommonTableColumn>{item.createdAt}</CommonTableColumn>
               </CommonTableRow>
             ))}
-          </CommonTable></>
+          </CommonTable>
+          <ReactPaginate
+            previousLabel={'이전'}
+            nextLabel={'다음'}
+            breakLabel={'...'}
+            pageCount={pageCount}
+            marginPagesDisplayed={2}
+            pageRangeDisplayed={5}
+            onPageChange={handlePageClick}
+            containerClassName={'pagination'}
+            activeClassName={'active'}
+          />
+          </>
         )}
     </div>
   );


### PR DESCRIPTION
# Add Board Basic Function & fixed React & NodeJS Manual(1.1.13)

<br>

**1. Board Modify(Update) 기능 추가**
     - 글쓴이에게 수정 권한 지급
     - 이외의 접근은 접근 못하도록 구성
     - title 공백 현상 수정

![화면 캡처 2024-07-26 211810](https://github.com/user-attachments/assets/9cc4d3eb-df49-4f8b-84b2-be0fc40fd21e)

<br>

**2. Board, MyPage 에 Pagination 기능 구현**
     - 페이지 당 10개로 구성하여 Pagination 구현
     - 현재로서 이전 페이지로 되돌아가는 기능이 미흡하므로 구현 예정
     (지금은 5페이지에서 Board_Detail 로 갔다가 뒤로가면 1페이지로 돌아가는 형태)

![화면 캡처 2024-07-26 211733](https://github.com/user-attachments/assets/a6ca7e87-4a8a-4af1-bd25-0c761a014b50)

<br>

**3. Manual 정비 및 MongoDB 스키마 수정**
     - User 회원가입 2글자 미만으로 금지되도록 반영하여 수정
     - Manual 간단 업데이트
     - Image Server 와 MongoDB 의 연계를 위해 Board 스키마를 조금 수정할 예정

![화면 캡처 2024-07-26 211852](https://github.com/user-attachments/assets/858fe59e-41bf-48fe-9b05-fd04d12714e2)

<br>

___

# ToDo

1. Pagination 기능 활용을 위해 되돌아가는 기능 정비
2. Board 스키마는 현재 글쓴이, 고유 번호, 내용, 제목, 생성 시기 가 존재하는데, 여기에 Image 의 경로 등을 Array 로 받을 것을 고려 중임
3. WYSIWYG Editor 의 3D 기능에 대한 연구 -> 현재 Board 안에 넣는 방안을 고려 중
4. 디자인 이쁘게 꾸미기 -> Home 에 뭔가 더 추가하거나 다른 Router 들 css 수준 향상